### PR TITLE
First parser for ecdc world case+death statistics.

### DIFF
--- a/parse_all.sh
+++ b/parse_all.sh
@@ -1,5 +1,7 @@
 python3 parsers/world.py
 
+python3 parsers/ecdc.py
+
 python3 parsers/italy.py
 
 python3 parsers/switzerland.py

--- a/parsers/cds.py
+++ b/parsers/cds.py
@@ -1,0 +1,104 @@
+'''
+parse country case counts provided by coronadatascraper.com and write results to TSV
+this should be run from the top level of the repo.
+
+Will need to be integrated with other parsers once they become available.
+'''
+import csv
+import json
+from urllib.request import urlopen
+
+from collections import defaultdict
+from datetime import datetime, timedelta
+from .utils import write_tsv
+
+# -----------------------------------------------------------------------------
+# Globals
+
+URL  = 'https://coronadatascraper.com/timeseries-byLocation.json'
+LOC  = 'case-counts'
+cols = ['location', 'time', 'cases', 'deaths', 'hospitalized', 'ICU', 'recovered']
+
+# -----------------------------------------------------------------------------
+# Functions
+
+def sorted_date(s):
+    return sorted(s, key=lambda d: datetime.strptime(d["time"], "%Y-%m-%d"))
+
+def stoi(x):
+    if x == "":
+        return 0
+
+    return int(x)
+
+def parse_countries():
+    # read the country_codes.csv for official country names
+    country_names = {}
+    file = "country_codes.csv"    
+    countries = defaultdict(lambda: defaultdict(list))
+    with open(file) as f:
+        rdr = csv.reader(f)
+        next(rdr)
+        for row in rdr:
+            countries[row[2]] = row[0]
+    return countries
+
+def retrieve_case_data():
+    countries = parse_countries()
+    
+    cases = defaultdict(list)
+
+    with urlopen(URL) as url:
+        data = json.loads(url.read().decode())
+
+    # example structure
+    #  "THA": {
+    #    "dates": {
+    #      "2020-1-22": {
+    #        "cases": 2,
+    #        "deaths": 0,
+    #        "recovered": 0,
+    #        "active": 2
+    
+    for c in data:
+
+        # replace country name if we have the "official" one in country_codes.csv
+        if c in countries:
+            country = countries[c]
+        else:
+            print('Error: %s not in country_code.csv, skipping'%c)
+            continue
+        for d in data[c]['dates']:
+            vals = {'time': d, 'cases': '0', 'deaths': "0"}
+            for k in ['deaths', 'cases', 'recovered']:
+                if k in data[c]['dates'][d]:
+                    vals[k] = str(data[c]['dates'][d][k])                
+            cases[country].append(vals)
+
+    for cntry, data in cases.items():
+        cases[cntry] = sorted_date(cases[cntry])
+        
+    return dict(cases)
+
+
+def flatten(cases):
+    rows = []
+    for cntry, data in cases.items():
+        for datum in data:
+            rows.append([cntry, datum['time'], datum['cases'], datum['deaths'], None, None, None])
+
+    return rows
+
+# -----------------------------------------------------------------------------
+# Main point of entry
+
+def parse():
+    cases = retrieve_case_data()
+    cases = flatten(cases)
+
+    write_tsv(f"{LOC}/cds.tsv", cols, cases, "cds")
+
+if __name__ == "__main__":
+    # for debugging
+    cases = retrieve_case_data()
+    cases = flatten(cases)

--- a/parsers/ecdc.py
+++ b/parsers/ecdc.py
@@ -107,7 +107,7 @@ def parse():
     cases = retrieve_case_data()
     cases = flatten(cases)
 
-    write_tsv(f"{LOC}/ecdcWorld.tsv", cols, cases, "ecdc")
+    write_tsv(f"{LOC}/World.tsv", cols, cases, "ecdc")
 
 if __name__ == "__main__":
     # for debugging

--- a/parsers/ecdc.py
+++ b/parsers/ecdc.py
@@ -107,7 +107,7 @@ def parse():
     cases = retrieve_case_data()
     cases = flatten(cases)
 
-    write_tsv(f"{LOC}/ecdcWorld.tsv", cols, cases, "world")
+    write_tsv(f"{LOC}/ecdcWorld.tsv", cols, cases, "ecdc")
 
 if __name__ == "__main__":
     # for debugging

--- a/parsers/ecdc.py
+++ b/parsers/ecdc.py
@@ -50,7 +50,7 @@ def retrieve_case_data():
         i += 1
     for row_index in range(1, worksheet.nrows):
         row = worksheet.row_values(row_index)
-        country, date = row[Ix['Countries and territories']], "-".join([str(int(row[Ix['Year']])), str(int(row[Ix['Month']])), str(int(row[Ix['Day']]))])
+        country, date = row[Ix['Countries and territories']].replace("_"," "), "-".join([str(int(row[Ix['Year']])), str(int(row[Ix['Month']])), str(int(row[Ix['Day']]))])
         # note: Cases are per day, not cumulative. We need to aggregate later
         cases[country].append({"time": date, "deaths": stoi(row[Ix['Deaths']]), "cases":  stoi(row[Ix['Cases']])})
 

--- a/parsers/ecdc.py
+++ b/parsers/ecdc.py
@@ -1,0 +1,91 @@
+'''
+parse country case counts provided by ECDC and write results to TSV
+this should be run from the top level of the repo.
+
+Will need to be integrated with other parsers once they become available.
+'''
+import xlrd
+from urllib.request import urlretrieve
+
+from collections import defaultdict
+from datetime import datetime, timedelta
+from .utils import write_tsv
+
+# -----------------------------------------------------------------------------
+# Globals
+
+URL  = "https://www.ecdc.europa.eu/sites/default/files/documents/COVID-19-geographic-disbtribution-worldwide-"
+LOC  = 'case-counts'
+cols = ['location', 'time', 'cases', 'deaths', 'hospitalized', 'ICU', 'recovered']
+
+# -----------------------------------------------------------------------------
+# Functions
+
+def sorted_date(s):
+    return sorted(s, key=lambda d: datetime.strptime(d["time"], "%Y-%m-%d"))
+
+def stoi(x):
+    if x == "":
+        return 0
+
+    return int(x)
+
+def retrieve_case_data():
+    cases = defaultdict(list)
+
+    # For now, always get the data from yesterday. We could make fancier check if today's data is already available
+    yesterday = datetime.today() - timedelta(days=1)
+    date = yesterday.strftime("%Y-%m-%d")
+    
+    file_name, headers = urlretrieve(URL+date+".xlsx")
+    workbook = xlrd.open_workbook(file_name)
+
+    #worksheet = workbook.sheet_by_name('COVID-19-geographic-disbtributi')
+    worksheet = workbook.sheet_by_index(0) # likely more stable
+
+    i = 0
+    Ix = {}
+    for c in worksheet.row_values(0):
+        Ix[c] = i
+        i += 1
+    for row_index in range(1, worksheet.nrows):
+        row = worksheet.row_values(row_index)
+        country, date = row[Ix['Countries and territories']], "-".join([str(int(row[Ix['Year']])), str(int(row[Ix['Month']])), str(int(row[Ix['Day']]))])
+        # note: Cases are per day, not cumulative. We need to aggregate later
+        cases[country].append({"time": date, "deaths": stoi(row[Ix['Deaths']]), "cases":  stoi(row[Ix['Cases']])})
+
+    for cntry, data in cases.items():
+        cases[cntry] = sorted_date(cases[cntry])
+
+    # aggregate cases here after sorting
+    for cntry, data in cases.items():
+        total = 0
+        for d in data:
+            total += d['cases']
+            d['cases'] = total
+        cases[cntry] = data
+        
+    return dict(cases)
+
+
+def flatten(cases):
+    rows = []
+    for cntry, data in cases.items():
+        for datum in data:
+            rows.append([cntry, datum['time'], datum['cases'], datum['deaths'], None, None, None])
+
+    return rows
+
+# -----------------------------------------------------------------------------
+# Main point of entry
+
+def parse():
+    cases = retrieve_case_data()
+    cases = flatten(cases)
+
+    write_tsv(f"{LOC}/ecdcWorld.tsv", cols, cases, "world")
+
+if __name__ == "__main__":
+    # for debugging
+    cases = retrieve_case_data()
+    cases = flatten(cases)

--- a/sources.json
+++ b/sources.json
@@ -18,5 +18,10 @@
     "primarySource": "https://covid.ourworldindata.org/data/full_data.csv",
     "dataProvenance": "WHO via OurWorldInData",
     "license": "CC-BY-4.0"
+  },
+  "ecdc": {
+    "primarySource": "https://www.ecdc.europa.eu/sites/default/files/documents/COVID-19-geographic-disbtribution-worldwide-<DATE>-xlsx",
+    "dataProvenance": "European Centre for Disease Prevention and Control",
+    "license": "The downloadable data file is updated daily and contains the latest available public data on COVID-19. Public-use data files allows users to manipulate the data in a format appropriate for their analyses. Users of ECDC public-use data files must comply with data use restrictions to ensure that the information will be used solely for statistical analysis or reporting purposes."
   }
 }

--- a/sources.json
+++ b/sources.json
@@ -18,5 +18,10 @@
     "primarySource": "https://www.ecdc.europa.eu/sites/default/files/documents/COVID-19-geographic-disbtribution-worldwide-<DATE>-xlsx",
     "dataProvenance": "European Centre for Disease Prevention and Control",
     "license": "The downloadable data file is updated daily and contains the latest available public data on COVID-19. Public-use data files allows users to manipulate the data in a format appropriate for their analyses. Users of ECDC public-use data files must comply with data use restrictions to ensure that the information will be used solely for statistical analysis or reporting purposes."
+  },
+  "cds": {
+    "primarySource": "https://coronadatascraper.com/timeseries-byLocation.json",
+    "dataProvenance": "Coronadatascraper.com",
+    "license": "Scraped from many sources, no clear license"
   }
 }

--- a/sources.json
+++ b/sources.json
@@ -14,11 +14,6 @@
     "dataProvenance": "The COVID Tracking Project",
     "license": "Apache License 2.0"
   },
-  "world": {
-    "primarySource": "https://covid.ourworldindata.org/data/full_data.csv",
-    "dataProvenance": "WHO via OurWorldInData",
-    "license": "CC-BY-4.0"
-  },
   "ecdc": {
     "primarySource": "https://www.ecdc.europa.eu/sites/default/files/documents/COVID-19-geographic-disbtribution-worldwide-<DATE>-xlsx",
     "dataProvenance": "European Centre for Disease Prevention and Control",


### PR DESCRIPTION
 Will pull ECDC data from yesterday (local time) for now. Country names might need to be fixed (didn't find an easy way to check yet). Creates case-counts/ecdcWorld.tsv, but should eventually replace World.tsv I assume. This diff does not yet disable the world.py