### PR TITLE
Cleanup of general data storage in parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,16 +181,15 @@ The steps to follow are:
       - The time column **must** be a string formatted as ``YYYY-MM-DD``
       - Try to keep the same order of columns for hygiene, although it should not ultimately matter
       - If data is missing, please leave the entry empty
+      - Use the store_data() function in utils to store the data into .tsv and .json files automatically
   * Place the script into the parsers directory
       - The name should correspond to the region name desired in the scenario.
-      - There **must** be a function parse() defined that outputs the TSV into the correct directory.
-  * Commit the produced ``.tsv`` file into the correct directory
+      - There **must** be a function parse() defined that calls store_data() from utils
+  * Ensure that the path provided to store_data() is well formatted
       - The structure of the directory is Region/Sub-Region/Country/
       - Region and Sub-Region are designated as per the U.N.
       - U.N. designations are found within country_codes.csv
       - Please use only the U.N. designated name for the country, region, and sub-region.
-  * All TSV files will be bundled into a json database into the app on next build
-      - The case counts should be displayed as data-points onto the associated scenario
 ##### Update the *sources.json* file to contain all relevant metadata.
   * The three fields are:
       - primarySource = The URL/path to the raw data

--- a/parsers/ecdc.py
+++ b/parsers/ecdc.py
@@ -11,7 +11,7 @@ import json
 from urllib.request import urlretrieve
 from collections import defaultdict
 from datetime import datetime, timedelta
-from .utils import write_tsv, sorted_date, flatten, parse_countries, stoi, store_json
+from .utils import sorted_date, parse_countries, stoi, store_data
 
 # -----------------------------------------------------------------------------
 # Globals
@@ -82,12 +82,7 @@ def retrieve_case_data():
 
 def parse():
     cases = retrieve_case_data()
-    store_json(cases)
-
-
-    # for legacy support
-    cases = flatten(cases)
-    write_tsv(f"{LOC}/World.tsv", cols, cases, "ecdc")
+    store_data(cases, {'default': LOC+'/World.tsv'}, 'ecdc')
     
 
 

--- a/parsers/germany.py
+++ b/parsers/germany.py
@@ -4,7 +4,7 @@ import csv
 import io
 
 from collections import defaultdict
-from .utils import write_tsv, store_json, list_to_dict
+from .utils import store_data
 
 # ------------------------------------------------------------------------
 # Globals
@@ -62,13 +62,4 @@ def parse():
             bundesland = bundesland_codes[row[1]]
             regions[bundesland].append([date, to_int(row[2]), to_int(row[3]), None, None, None])
 
-    for region, data in regions.items():
-        write_tsv(f"{LOC}/{region}.tsv", cols, data, "germany")
-
-    # prepare dict for json
-    regions2 = {}
-    for region, data in regions.items():
-        regions2["DEU-"+region] = data
-
-    regions3 = list_to_dict(regions2, cols)
-    store_json(regions3)
+    store_data(regions, { 'default': LOC}, 'germany', 'DEU', cols)

--- a/parsers/india.py
+++ b/parsers/india.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from collections import defaultdict
 from datetime import datetime
-from .utils import write_tsv, list_to_dict, store_json
+from .utils import store_data
 
 # ------------------------------------------------------------------------
 # Globals
@@ -53,21 +53,4 @@ def parse():
     for cntry, data in states.items():
         states[cntry] = sorted_date(states[cntry])
 
-    for state, data in states.items():
-        try:
-            state = state.replace(' / ','_')
-            write_tsv(f"{LOC}/{state}.tsv", cols, data, "india")
-        except FileNotFoundError as e:
-            print(f"dumping data for '{state}' failed.")
-            raise e
-
-    # prepare dict for json
-    regions2 = {}
-    for region, data in states.items():
-        if not (region == "India"):
-            regions2["IND-"+region] = data
-        else:
-            regions2[region] = data
-
-    regions3 = list_to_dict(regions2, cols)
-    store_json(regions3)
+    store_data(states, { 'default': LOC}, 'india', 'IND', cols)

--- a/parsers/italy.py
+++ b/parsers/italy.py
@@ -5,7 +5,7 @@ import requests
 import numpy as np
 
 from collections import defaultdict
-from .utils import write_tsv, store_json, list_to_dict
+from .utils import store_data
 
 # ------------------------------------------------------------------------
 # Globals
@@ -57,16 +57,4 @@ def parse():
     for date, counts in dates.items():
         regions["Italy"].append([date] + [int(c) for c in counts])
 
-    for region, data in regions.items():
-        write_tsv(f"{LOC}/{region}.tsv", cols, data, "italy")
-
-    # prepare dict for json
-    regions2 = {}
-    for region, data in regions.items():
-        if not region == "Italy":
-            regions2["ITA-"+region] = data
-        else:
-            regions2[region] = data
-    regions3 = list_to_dict(regions2, cols)
-    store_json(regions3)
-
+    store_data(regions, { 'default': LOC}, 'italy', 'ITA', cols)

--- a/parsers/spain.py
+++ b/parsers/spain.py
@@ -66,4 +66,6 @@ def parse():
                                          x[1].get("ICU", None),
                                          x[1].get("recovered", None)] for x in dps]
 
+    region_tables['Spain'] = region_tables['Total']
+    del region_tables['Total']
     store_data(region_tables, { 'default': LOC, 'Spain': LOC}, 'spain', 'ESP', cols)

--- a/parsers/spain.py
+++ b/parsers/spain.py
@@ -5,7 +5,7 @@ import io
 from datetime import datetime
 
 from collections import defaultdict
-from .utils import write_tsv, list_to_dict, store_json
+from .utils import store_data
 
 # ------------------------------------------------------------------------
 # Globals
@@ -66,19 +66,4 @@ def parse():
                                          x[1].get("ICU", None),
                                          x[1].get("recovered", None)] for x in dps]
 
-    for region, data in region_tables.items():
-        if region == "Total":
-            write_tsv(f"{LOC}/Spain.tsv", cols, data, "spain")
-        else:
-            write_tsv(f"{LOC}/{region}.tsv", cols, data, "spain")
-
-    # prepare dict for json
-    regions2 = {}
-    for region, data in region_tables.items():
-        if not (region == "Spain"):
-            regions2["ESP-"+region] = data
-        else:
-            regions2[region] = data
-
-    regions3 = list_to_dict(regions2, cols)
-    store_json(regions3)
+    store_data(region_tables, { 'default': LOC, 'Spain': LOC}, 'spain', 'ESP', cols)

--- a/parsers/switzerland.py
+++ b/parsers/switzerland.py
@@ -4,7 +4,7 @@ import csv
 import io
 
 from collections import defaultdict
-from .utils import write_tsv, store_json, list_to_dict
+from .utils import store_data
 
 # ------------------------------------------------------------------------
 # Globals
@@ -74,19 +74,4 @@ def parse():
         canton = cantonal_codes[row[1]]
         regions[canton].append([date, to_int(row[2]), to_int(row[5]), to_int(row[6]), None, to_int(row[7])])
 
-    for region, data in regions.items():
-        if region != "Liechtenstein":
-            write_tsv(f"{LOC}/{region}.tsv", cols, data, "switzerland")
-        else:
-            write_tsv(f"{LOC2}/{region}.tsv", cols, data, "switzerland")
-
-    # prepare dict for json
-    regions2 = {}
-    for region, data in regions.items():
-        if not ((region == "Liechtenstein") or (region == "Switzerland")):
-            regions2["CHE-"+region] = data
-        else:
-            regions2[region] = data
-        
-    regions3 = list_to_dict(regions2, cols)
-    store_json(regions3)
+    store_data(regions, { 'default': LOC, 'Liechtenstein': LOC2, 'Switzerland': LOC}, 'switzerland','CHE', cols)

--- a/parsers/tsv.py
+++ b/parsers/tsv.py
@@ -2,6 +2,7 @@
 parse all manually maintained .tsv files in the case-counts/ folder
 this should be run from the top level of the repo.
 '''
+import sys
 import csv
 import os
 import json
@@ -61,7 +62,7 @@ def parse_world(tsv):
         try:
             idx[col] = hdr.index(col)
         except:
-            print(col, hdr)
+            print(col, cols, hdr)
             return None, False
 
     data = defaultdict(list)

--- a/parsers/unitedstates.py
+++ b/parsers/unitedstates.py
@@ -7,7 +7,7 @@ import json
 
 from collections import defaultdict
 from datetime import datetime
-from .utils import write_tsv, store_json, list_to_dict, stoi
+from .utils import store_data, stoi
 
 # ------------------------------------------------------------------------
 # Globals
@@ -109,16 +109,4 @@ def parse():
     for cntry, data in regions.items():
         regions[cntry] = sorted_date(regions[cntry])
 
-    for region, data in regions.items():
-        write_tsv(f"{LOC}/{region}.tsv", cols, data, "unitedstates")
-
-    # prepare dict for json
-    regions2 = {}
-    for region, data in regions.items():
-        if not (region == "USA"):
-            regions2["USA-"+region] = data
-        else:
-            regions2[region] = data
-
-    regions3 = list_to_dict(regions2, cols)
-    store_json(regions3)
+    store_data(regions, { 'default': LOC}, 'unitedstates', 'USA', cols)

--- a/parsers/utils.py
+++ b/parsers/utils.py
@@ -178,8 +178,17 @@ def sanitize(fname):
     
     
 def store_data(regions, exceptions, source, code='', cols=[]):
-    # check if we have a dict of list of list, or dict of list of dicts
+    """ Store data to .tsv and .json files
 
+    Keyword arguments:
+    regions -- a dict of lists of lists {'USA': [['2020-03-20', 0, ...], ...]}, or a dict of lists of dicts {'USA': [{'cases': 0, 'time': '2020-03-20'}, ... ] }
+    exceptions -- a dict that provides the path for .tsv files. Needs at least a {'default': LOC} entry. If region and total data is available, this typically looks like {'default': LOC, 'Spain': LOC}
+    source --  the string identifyig the source in sources.json
+    code -- the three letter code for the country from country_codes.csv
+    cols -- the colum headers that were used to prepare the innermost list
+    """    
+    
+    # check if we have a dict of list of list, or dict of list of dicts
     if isinstance(regions, dict):
         cd1 = list(regions.values())[0]
         if isinstance(cd1, list): 


### PR DESCRIPTION
This patch provides store_data() in utils, which takes care of .tsv and json storage for the parsers. The function expects a bunch of arguments which hopefully are simple to understand. The primary goal here is to make parser writing easier and abstract the .tsv and .json side away. This also enables us to perform sanitization at a central location. I added first sanitization of the .tsv file names (for security reasons, as those strings come from the remote API). All current parsers are patched already, and diffs of the .tsv show no problems (to me). 