### PR TITLE
Feat/scenarios ode fit

### DIFF
--- a/generate_data.py
+++ b/generate_data.py
@@ -15,6 +15,7 @@ if __name__ == "__main__":
     parser.add_argument('--output-cases', type=str, default=None, help='path to case-counts file')
     parser.add_argument('--output-population', type=str, default=None, help='path to population file')
     parser.add_argument('--output-scenarios', type=str, default=None, help='path to scenarios file')
+    parser.add_argument('--num-threads', type=int, default=1, help='number of threads to open for fitting')
     args = parser.parse_args()
 
     if not os.path.isdir(BASE_PATH):
@@ -47,4 +48,4 @@ if __name__ == "__main__":
     if args.output_scenarios:
         print(f"Generating scenario json")
         scenarios = importlib.import_module(f"scripts.scenarios")
-        scenarios.generate(args.output_scenarios)
+        scenarios.generate(args.output_scenarios, num_procs=args.num_threads)

--- a/scripts/model.py
+++ b/scripts/model.py
@@ -120,10 +120,10 @@ class Params(Data):
         self.time  = times
 
         # Make infection function
-        phase_offset = (times[0] - JAN1_2019)
+        # phase_offset = (times[0] - JAN1_2019)
         beta = self.rates.infectivity
-        def infectivity(t):
-            return beta*(1 + 0.2*np.cos(2*np.pi*(t + phase_offset)/365))
+        # def infectivity(t):
+        #     return beta*(1 + 0.2*np.cos(2*np.pi*(t + phase_offset)/365))
 
         self.rates.infectivity = lambda t:beta #infectivity
 
@@ -228,6 +228,9 @@ def assess_model(params, data, cases):
 
 # Any parameters given in guess are fit. The remaining are fixed and set by DefaultRates
 def fit_params(key, time_points, data, guess, bounds=None):
+    if key not in POPDATA:
+        return Params(None, None, None, DefaultRates, Fracs()), 10, (False, "Not within population database")
+
     params_to_fit = {key : i for i, key in enumerate(guess.keys())}
 
     def pack(x, as_list=False):
@@ -278,6 +281,9 @@ def load_data(key):
     data[Sub.D] = np.concatenate([[np.nan], data[Sub.D][good_idx]])
     data[Sub.T] = np.concatenate([[np.nan], data[Sub.T][good_idx]])
 
+    if sum(good_idx) == 0:
+        return None, None
+
     # np.where(good_idx)[0][0] is the first day with case_min cases
     # start the model 3 weeks prior.
     idx = np.where(good_idx)[0][0]
@@ -291,6 +297,9 @@ def load_data(key):
 
 def fit_population(region, guess=None):
     time_points, data = load_data(region)
+    if data is None or len(data[Sub.D]) <= 5:
+        return None
+
     if guess is None:
         guess = { "R0": 3.0,
                   "reported" : 0.3,
@@ -306,7 +315,6 @@ def fit_population(region, guess=None):
 # Testing entry
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser(description = "",
                                      usage="fit data")
 

--- a/scripts/model.py
+++ b/scripts/model.py
@@ -24,6 +24,9 @@ JAN1_2019      = datetime.strptime("2019-01-01", "%Y-%m-%d").toordinal()
 JUN1_2019      = datetime.strptime("2019-06-01", "%Y-%m-%d").toordinal()
 JAN1_2020      = datetime.strptime("2020-01-01", "%Y-%m-%d").toordinal()
 
+CASES = importlib.import_module(f"scripts.tsv")
+CASE_DATA = CASES.parse()
+
 def load_distribution(path):
     dist = {}
     with open(path, 'r') as fd:
@@ -261,10 +264,7 @@ def load_data(key):
     days = []
     case_min, case_max = 20, 1e4
 
-    cases = importlib.import_module(f"scripts.tsv")
-
-    db = cases.parse()
-    ts = db[key]
+    ts = CASE_DATA[key]
 
     days = [d['time'].split('T')[0] for d in ts]
     for tp in ts:
@@ -289,15 +289,15 @@ def load_data(key):
     return times, data
 
 
-def fit_population(population):
+def fit_population(region, guess=None):
+    time_points, data = load_data(region)
+    if guess is None:
+        guess = { "R0": 3.0,
+                  "reported" : 0.3,
+                  "logInitial" : 1
+                }
 
-    time_points, data = load_data(population)
-
-    guess = { "R0": 3.0,
-              "reported" : 0.3,
-              "logInitial" : 1
-            }
-    param, init_cases, err = fit_params(population, time_points, data, guess)
+    param, init_cases, err = fit_params(region, time_points, data, guess)
     tMin = datetime.strftime(datetime.fromordinal(time_points[0]), '%Y-%m-%d')
     return {'params':param, 'initialCases':init_cases, 'tMin':tMin, 'data': data, 'error':err}
 

--- a/scripts/scenarios.py
+++ b/scripts/scenarios.py
@@ -207,9 +207,9 @@ def set_mitigation(cases, scenario):
 
     case_counts = np.array([c['cases'] for c in valid_cases])
     levelOne = np.where(case_counts > min(max(5, scenario.population.populationServed/1e5),200))[0]
-    levelTwo = np.where(case_counts > min(max(5, scenario.population.populationServed/1e4),2000))[0]
+    levelTwo = np.where(case_counts > min(max(5, scenario.population.populationServed/1e3),10000))[0]
 
-    for name, level, val in [("levelOne", levelOne, 0.6), ('levelTwo', levelTwo, 0.5)]:
+    for name, level, val in [("levelOne", levelOne, 0.8), ('levelTwo', levelTwo, 0.6)]:
         if len(level):
             level_idx = level[0]
             cutoff_str = valid_cases[level_idx]["time"][:10]

--- a/scripts/scenarios.py
+++ b/scripts/scenarios.py
@@ -8,6 +8,7 @@ import sys
 sys.path.append('..')
 from paths import TMP_CASES, BASE_PATH, JSON_DIR
 from scripts.tsv import parse as parse_tsv
+from scripts.model import fit_population
 
 # ------------------------------------------------------------------------
 # Globals
@@ -161,13 +162,16 @@ def marshalJSON(obj, wtr):
     return json.dump(obj, wtr, default=lambda x: x.__dict__, sort_keys=True, indent=4)
 
 def fit_all_case_data():
-    Params = Fitter()
+    # Params = Fitter()
+    def unpack(fit):
+        return {"tMin": fit['tMin'], "r0": fit['params'].rates.R0, "initialCases": fit["initialCases"]}
 
     case_counts = parse_tsv()
     for region, data in case_counts.items():
-        fit = Params.fit(data)
-        if fit:
-            FIT_CASE_DATA[region] = fit
+        # fit = Params.fit(data)
+        # if fit:
+        print(f"Fitting '{region}'")
+        FIT_CASE_DATA[region] = unpack(fit_population(region))
 
 # ------------------------------------------------------------------------
 # Main point of entry
@@ -186,7 +190,6 @@ def generate(OUTPUT_JSON):
                'icus' : hdr.index('ICUBeds'),
                'hemisphere' : hdr.index('hemisphere')}
 
-        
         args = ['name', 'ages', 'size', 'beds', 'icus', 'hemisphere']
         for region in rdr:
             entry = [region[idx[arg]] for arg in args]

--- a/scripts/scenarios.py
+++ b/scripts/scenarios.py
@@ -142,7 +142,7 @@ class ContainmentParams(Object):
         #self.reduction    = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
         self.reduction    = np.ones(15)
         self.numberPoints = len(self.reduction)
-        self.measures = []
+        self.mitigationIntervals = []
 
 
 class DateRange(Object):
@@ -216,7 +216,7 @@ def set_mitigation(cases, scenario):
             cutoff = datetime.strptime(cutoff_str, '%Y-%m-%d').toordinal()
 
             scenario.containment.reduction[timeline>cutoff] *= val
-            scenario.containment.measures.append(Measure(name, cutoff_str, 
+            scenario.containment.mitigationIntervals.append(Measure(name, cutoff_str, 
                 scenario.simulation.simulationTimeRange.tMax[:10], 
                 val))
 


### PR DESCRIPTION
Use the current scenario fitter as a backstop if we don't have any population data to pull from. Replaces this with the ODE fitter. As it's slower, I added another parameter which allows one to specify the number of threads to parrallelize the fitting procedure. 

The generated scenarios seem to fit well. I think this is ready to be integrated into the main pipeline - it should improve the initial model predictions.